### PR TITLE
Update: copy rule

### DIFF
--- a/_tasks/copy-rules.ts
+++ b/_tasks/copy-rules.ts
@@ -74,14 +74,8 @@ async function processCursorRules() {
   for (const file of ruleFiles) {
     const fileName = path.basename(file, ".md");
 
-    // For core-rule.md rename to cursor-core-rule
-    // For gas-rule.md rename to cursor-gas-rule
-    let newFileName = fileName;
-    if (fileName === "core-rule") {
-      newFileName = `${editor}-core-rule`;
-    } else if (fileName === "gas-rule") {
-      newFileName = `${editor}-gas-rule`;
-    }
+    // Rename all rules to have editor prefix (e.g., cursor-rule-name)
+    const newFileName = `${editor}-${fileName}`;
 
     const sourceFile = Bun.file(file);
     const content = await sourceFile.text();


### PR DESCRIPTION
This pull request simplifies the logic for renaming rule files in the `processCursorRules` function. Instead of handling specific cases for `core-rule.md` and `gas-rule.md`, the updated code now applies a consistent naming pattern to all rule files.

Key change:

* `processCursorRules` in `_tasks/copy-rules.ts`: Replaced conditional logic for renaming specific rule files with a generalized approach that prefixes all rule file names with the `editor` variable (e.g., `cursor-rule-name`).