### PR TITLE
Add Reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ The `_tasks/copy-rules.ts` script copies and formats rules for different AI tool
 - For **Windsurf**: Merges rules into `.windsurfrules` in the project root
 - For **Copilot**: Merges rules into `.github/copilot-instructions.md`
 
-You can run these tasks via npm scripts (see next section).
+## References
+- [Cursor Rules](https://docs.cursor.com/context/rules)
+- [Windsurf Rules](https://docs.windsurf.com/windsurf/memories#memories-and-rules)
+- [GitHub Copilot Rules](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot#repository-custom-instructions-in-use)
+- [kinopeee/cursorrules](https://github.com/kinopeee/cursorrules)
 
 ## License
 MIT


### PR DESCRIPTION
This pull request updates the `README.md` file to include a new "References" section with links to documentation and resources related to the rules for different AI tools.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R119): Added a "References" section with links to documentation for Cursor Rules, Windsurf Rules, GitHub Copilot Rules, and a related GitHub repository.